### PR TITLE
Add in-memory DB with Data and an Entity class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,9 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.apache.commons:commons-csv:1.10.0'
+    implementation 'com.h2database:h2'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/com/gaeltech/ironbank/IronBankApplication.java
+++ b/src/main/java/com/gaeltech/ironbank/IronBankApplication.java
@@ -1,13 +1,33 @@
 package com.gaeltech.ironbank;
 
+import org.slf4j.Logger;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+import javax.sql.DataSource;
 
 @SpringBootApplication
 public class IronBankApplication {
+
+    private final Logger log = org.slf4j.LoggerFactory.getLogger(IronBankApplication.class);
 
     public static void main(String[] args) {
         SpringApplication.run(IronBankApplication.class, args);
     }
 
+    @Bean
+    CommandLineRunner runner(WorkoutRepository repository, DataSource dataSource) {
+        return args -> {
+            // Initialize database with src/main/resources/data.sql
+            Resource resource = new ClassPathResource("data.sql");
+            ResourceDatabasePopulator databasePopulator = new ResourceDatabasePopulator(resource);
+            databasePopulator.execute(dataSource);
+            log.info("Workout table exists with record count: {}", repository.count());
+        };
+    }
 }

--- a/src/main/java/com/gaeltech/ironbank/WorkoutEntity.java
+++ b/src/main/java/com/gaeltech/ironbank/WorkoutEntity.java
@@ -1,0 +1,106 @@
+package com.gaeltech.ironbank;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "workouts")
+public class WorkoutEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private int numberOfReps;
+    @Enumerated(EnumType.STRING)
+    private ExerciseType exerciseType;
+    private String notes;
+
+    public WorkoutEntity() {
+    }
+
+    public WorkoutEntity(Long id, LocalDateTime startTime, LocalDateTime endTime, int numberOfReps, ExerciseType exerciseType, String notes) {
+        this.id = id;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.numberOfReps = numberOfReps;
+        this.exerciseType = exerciseType;
+        this.notes = notes;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public int getNumberOfReps() {
+        return numberOfReps;
+    }
+
+    public void setNumberOfReps(int numberOfReps) {
+        this.numberOfReps = numberOfReps;
+    }
+
+    public ExerciseType getExerciseType() {
+        return exerciseType;
+    }
+
+    public void setExerciseType(ExerciseType exerciseType) {
+        this.exerciseType = exerciseType;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    @Override
+    public String toString() {
+        return "WorkoutEntity{" +
+                "id=" + id +
+                ", startTime='" + startTime + '\'' +
+                ", endTime='" + endTime + '\'' +
+                ", numberOfReps=" + numberOfReps +
+                ", exerciseType=" + exerciseType +
+                ", notes='" + notes + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WorkoutEntity that = (WorkoutEntity) o;
+        return getNumberOfReps() == that.getNumberOfReps() && Objects.equals(getId(), that.getId()) && Objects.equals(getStartTime(), that.getStartTime()) && Objects.equals(getEndTime(), that.getEndTime()) && getExerciseType() == that.getExerciseType() && Objects.equals(getNotes(), that.getNotes());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getStartTime(), getEndTime(), getNumberOfReps(), getExerciseType(), getNotes());
+    }
+}

--- a/src/main/java/com/gaeltech/ironbank/WorkoutRepository.java
+++ b/src/main/java/com/gaeltech/ironbank/WorkoutRepository.java
@@ -1,0 +1,8 @@
+package com.gaeltech.ironbank;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WorkoutRepository extends JpaRepository<WorkoutEntity, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,21 @@
 spring.application.name=iron-bank
+
+# DB
+spring.datasource.url=jdbc:h2:mem:ironbankdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=admin
+spring.datasource.password=admin
+
+# H2 console
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# Enable schema creation
+# Prevent data initialization - currently done manually in IronBankApplication class due to error
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.sql.init.mode=never
+
+# Logging
+logging.level.org.springframework.jdbc.datasource.init=DEBUG
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,3 @@
+INSERT INTO workouts (start_time, end_time, number_of_reps, exercise_type, notes) VALUES
+                                                                                      ('2024-05-30 08:00:00', '2024-05-30 09:00:00', 10, 'BENCH_PRESS', 'First workout'),
+                                                                                      ('2024-05-30 09:00:00', '2024-05-30 10:00:00', 15, 'SQUAT', 'Second workout');


### PR DESCRIPTION
Normally you throw a SQL file with some data into a file like
`src/main/resources/data.sql` and then set the property in application.properties to load it on startup - this will run the script and add the rows to your table:  
`spring.sql.init.mode=always`   

Our DB table is auto-created by the @Entity tag at the top of our WorkoutEntity class when this is set:
`spring.jpa.hibernate.ddl-auto=create-drop`  

However, for some reason no matter what I tried it always tried to run the script before the table existed. Had to turn it off in properties and add manual running of the script in the main IronBankApplication class. 

It will do for now.